### PR TITLE
feat: Add JSON configuration file system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 .hytale-downloader-credentials.json
 temp_decompile/
 *.zip
+bin/

--- a/hyfixes-early/src/main/java/com/hyfixes/early/ArchetypeChunkTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/ArchetypeChunkTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -43,6 +44,12 @@ public class ArchetypeChunkTransformer implements ClassTransformer {
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         // Only transform the ArchetypeChunk class
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("archetypeChunk")) {
+            System.out.println("[HyFixes-Early] ArchetypeChunkTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/BeaconSpawnControllerTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/BeaconSpawnControllerTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -36,6 +37,12 @@ public class BeaconSpawnControllerTransformer implements ClassTransformer {
     @Override
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("beaconSpawnController")) {
+            System.out.println("[HyFixes-Early] BeaconSpawnControllerTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/BlockComponentChunkTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/BlockComponentChunkTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -39,6 +40,12 @@ public class BlockComponentChunkTransformer implements ClassTransformer {
     @Override
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("blockComponentChunk")) {
+            System.out.println("[HyFixes-Early] BlockComponentChunkTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/CommandBufferTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/CommandBufferTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -49,6 +50,12 @@ public class CommandBufferTransformer implements ClassTransformer {
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         // Only transform the CommandBuffer class
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("commandBuffer")) {
+            System.out.println("[HyFixes-Early] CommandBufferTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/InteractionChainTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/InteractionChainTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -39,6 +40,12 @@ public class InteractionChainTransformer implements ClassTransformer {
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         // Only transform the InteractionChain class
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("interactionChain")) {
+            System.out.println("[HyFixes-Early] InteractionChainTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/SpawnMarkerEntityTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/SpawnMarkerEntityTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -44,6 +45,12 @@ public class SpawnMarkerEntityTransformer implements ClassTransformer {
     @Override
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("spawnMarkerEntity")) {
+            System.out.println("[HyFixes-Early] SpawnMarkerEntityTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/SpawnMarkerSystemsTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/SpawnMarkerSystemsTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -41,6 +42,12 @@ public class SpawnMarkerSystemsTransformer implements ClassTransformer {
     @Override
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("spawnMarkerSystems")) {
+            System.out.println("[HyFixes-Early] SpawnMarkerSystemsTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/SpawnReferenceSystemsTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/SpawnReferenceSystemsTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -37,6 +38,12 @@ public class SpawnReferenceSystemsTransformer implements ClassTransformer {
     @Override
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("spawnReferenceSystems")) {
+            System.out.println("[HyFixes-Early] SpawnReferenceSystemsTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/TrackedPlacementTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/TrackedPlacementTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -41,6 +42,12 @@ public class TrackedPlacementTransformer implements ClassTransformer {
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         // Only transform the TrackedPlacement$OnAddRemove inner class
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("trackedPlacement")) {
+            System.out.println("[HyFixes-Early] TrackedPlacementTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/WorldMapTrackerTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/WorldMapTrackerTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -40,6 +41,12 @@ public class WorldMapTrackerTransformer implements ClassTransformer {
     @Override
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("worldMapTracker")) {
+            System.out.println("[HyFixes-Early] WorldMapTrackerTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/WorldTransformer.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/WorldTransformer.java
@@ -1,5 +1,6 @@
 package com.hyfixes.early;
 
+import com.hyfixes.early.config.EarlyConfigManager;
 import com.hypixel.hytale.plugin.early.ClassTransformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -45,6 +46,12 @@ public class WorldTransformer implements ClassTransformer {
     public byte[] transform(String className, String packageName, byte[] classBytes) {
         // Only transform the World class
         if (!className.equals(TARGET_CLASS)) {
+            return classBytes;
+        }
+
+        // Check if transformer is enabled via config
+        if (!EarlyConfigManager.getInstance().isTransformerEnabled("world")) {
+            System.out.println("[HyFixes-Early] WorldTransformer DISABLED by config");
             return classBytes;
         }
 

--- a/hyfixes-early/src/main/java/com/hyfixes/early/config/EarlyConfigManager.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/config/EarlyConfigManager.java
@@ -1,0 +1,164 @@
+package com.hyfixes.early.config;
+
+import com.google.gson.Gson;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Manages the HyFixes Early Plugin configuration.
+ * 
+ * Reads from the same config file as the runtime plugin: mods/hyfixes/config.json
+ * 
+ * Uses static initialization so transformers can access config before
+ * the runtime plugin loads.
+ */
+public class EarlyConfigManager {
+
+    private static final String CONFIG_DIR = "mods/hyfixes";
+    private static final String CONFIG_FILE = "config.json";
+    private static final Path CONFIG_PATH = Paths.get(CONFIG_DIR, CONFIG_FILE);
+
+    private static EarlyConfigManager instance;
+    private static final Object lock = new Object();
+
+    private EarlyPluginConfig config;
+    private boolean loadedFromFile = false;
+
+    /**
+     * Get the singleton instance, loading config on first access.
+     */
+    public static EarlyConfigManager getInstance() {
+        if (instance == null) {
+            synchronized (lock) {
+                if (instance == null) {
+                    instance = new EarlyConfigManager();
+                    instance.loadConfig();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Private constructor - use getInstance()
+     */
+    private EarlyConfigManager() {
+        this.config = new EarlyPluginConfig();
+    }
+
+    /**
+     * Load configuration from file.
+     * Note: The early plugin only reads the config, it doesn't create it.
+     * The runtime plugin is responsible for generating defaults.
+     */
+    private void loadConfig() {
+        try {
+            if (Files.exists(CONFIG_PATH)) {
+                try (Reader reader = new BufferedReader(new InputStreamReader(
+                        Files.newInputStream(CONFIG_PATH), StandardCharsets.UTF_8))) {
+                    Gson gson = new Gson();
+                    EarlyPluginConfig loaded = gson.fromJson(reader, EarlyPluginConfig.class);
+                    if (loaded != null) {
+                        this.config = loaded;
+                        this.loadedFromFile = true;
+                        System.out.println("[HyFixes-Early-Config] Loaded configuration from: " + CONFIG_PATH);
+                    } else {
+                        System.out.println("[HyFixes-Early-Config] Config file was empty, using defaults");
+                    }
+                }
+            } else {
+                System.out.println("[HyFixes-Early-Config] No config file found at: " + CONFIG_PATH);
+                System.out.println("[HyFixes-Early-Config] Using default settings. Config will be created by runtime plugin.");
+            }
+
+            // Apply environment variable overrides for verbose logging
+            applyEnvironmentOverrides();
+
+        } catch (Exception e) {
+            System.err.println("[HyFixes-Early-Config] Error loading config: " + e.getMessage());
+            System.err.println("[HyFixes-Early-Config] Using default configuration");
+            e.printStackTrace();
+            this.config = new EarlyPluginConfig();
+        }
+    }
+
+    /**
+     * Apply environment variable overrides.
+     */
+    private void applyEnvironmentOverrides() {
+        // HYFIXES_VERBOSE=true or -Dhyfixes.verbose=true
+        String verbose = System.getenv("HYFIXES_VERBOSE");
+        if (verbose == null) {
+            verbose = System.getProperty("hyfixes.verbose");
+        }
+        if ("true".equalsIgnoreCase(verbose)) {
+            config.early.logging.verbose = true;
+            System.out.println("[HyFixes-Early-Config] ENV override: early.logging.verbose = true (HYFIXES_VERBOSE)");
+        }
+    }
+
+    /**
+     * Get the current configuration.
+     */
+    public EarlyPluginConfig getConfig() {
+        return config;
+    }
+
+    /**
+     * Check if config was loaded from file.
+     */
+    public boolean isLoadedFromFile() {
+        return loadedFromFile;
+    }
+
+    // ============================================
+    // Convenience methods for transformer checks
+    // ============================================
+
+    /**
+     * Check if a transformer is enabled by name.
+     */
+    public boolean isTransformerEnabled(String name) {
+        EarlyPluginConfig.TransformersConfig t = config.transformers;
+        return switch (name.toLowerCase()) {
+            case "interactionchain" -> t.interactionChain;
+            case "world" -> t.world;
+            case "spawnreferencesystems" -> t.spawnReferenceSystems;
+            case "beaconspawncontroller" -> t.beaconSpawnController;
+            case "blockcomponentchunk" -> t.blockComponentChunk;
+            case "spawnmarkersystems" -> t.spawnMarkerSystems;
+            case "spawnmarkerentity" -> t.spawnMarkerEntity;
+            case "trackedplacement" -> t.trackedPlacement;
+            case "commandbuffer" -> t.commandBuffer;
+            case "worldmaptracker" -> t.worldMapTracker;
+            case "archetypechunk" -> t.archetypeChunk;
+            default -> {
+                System.err.println("[HyFixes-Early-Config] Unknown transformer: " + name);
+                yield true; // Default to enabled for safety
+            }
+        };
+    }
+
+    /**
+     * Check if verbose logging is enabled.
+     */
+    public boolean isVerbose() {
+        return config.early.logging.verbose;
+    }
+
+    // ============================================
+    // World transformer settings
+    // ============================================
+
+    public int getWorldRetryCount() {
+        return config.world.retryCount;
+    }
+
+    public long getWorldRetryDelayMs() {
+        return config.world.retryDelayMs;
+    }
+}

--- a/hyfixes-early/src/main/java/com/hyfixes/early/config/EarlyPluginConfig.java
+++ b/hyfixes-early/src/main/java/com/hyfixes/early/config/EarlyPluginConfig.java
@@ -1,0 +1,58 @@
+package com.hyfixes.early.config;
+
+/**
+ * HyFixes Early Plugin Configuration
+ * 
+ * This class mirrors the transformer-related settings from the main HyFixesConfig.
+ * It's loaded from the same config.json file as the runtime plugin.
+ */
+public class EarlyPluginConfig {
+
+    // Transformer toggles
+    public TransformersConfig transformers = new TransformersConfig();
+
+    // World transformer settings
+    public WorldConfig world = new WorldConfig();
+
+    // Early plugin logging
+    public EarlyConfig early = new EarlyConfig();
+
+    /**
+     * Transformer toggle configuration
+     */
+    public static class TransformersConfig {
+        public boolean interactionChain = true;
+        public boolean world = true;
+        public boolean spawnReferenceSystems = true;
+        public boolean beaconSpawnController = true;
+        public boolean blockComponentChunk = true;
+        public boolean spawnMarkerSystems = true;
+        public boolean spawnMarkerEntity = true;
+        public boolean trackedPlacement = true;
+        public boolean commandBuffer = true;
+        public boolean worldMapTracker = true;
+        public boolean archetypeChunk = true;
+    }
+
+    /**
+     * World transformer configuration
+     */
+    public static class WorldConfig {
+        public int retryCount = 5;
+        public long retryDelayMs = 20;
+    }
+
+    /**
+     * Early plugin configuration
+     */
+    public static class EarlyConfig {
+        public EarlyLoggingConfig logging = new EarlyLoggingConfig();
+    }
+
+    /**
+     * Early plugin logging configuration
+     */
+    public static class EarlyLoggingConfig {
+        public boolean verbose = false;
+    }
+}

--- a/hyfixes-early/src/main/resources/manifest.json
+++ b/hyfixes-early/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "Group": "com.hyfixes",
   "Name": "HyFixes-Early",
-  "Version": "1.6.1",
+  "Version": "1.7.0",
   "Description": "Bytecode transformers for HyFixes - Fixes deep networking bugs and combat desync issues.",
   "Main": "com.hyfixes.early.HyFixesEarly",
   "Authors": [

--- a/src/main/java/com/hyfixes/config/HyFixesConfig.java
+++ b/src/main/java/com/hyfixes/config/HyFixesConfig.java
@@ -1,0 +1,153 @@
+package com.hyfixes.config;
+
+/**
+ * HyFixes Configuration - Contains all runtime and early plugin settings.
+ * 
+ * This class is deserialized from config.json using Gson.
+ * All fields have default values that match the original hardcoded behavior.
+ */
+public class HyFixesConfig {
+
+    // Chunk unload settings
+    public ChunkUnloadConfig chunkUnload = new ChunkUnloadConfig();
+    
+    // Chunk cleanup settings
+    public ChunkCleanupConfig chunkCleanup = new ChunkCleanupConfig();
+    
+    // Sanitizer toggles
+    public SanitizersConfig sanitizers = new SanitizersConfig();
+    
+    // Interaction manager settings
+    public InteractionManagerConfig interactionManager = new InteractionManagerConfig();
+    
+    // Instance tracker settings
+    public InstanceTrackerConfig instanceTracker = new InstanceTrackerConfig();
+    
+    // Monitor settings
+    public MonitorConfig monitor = new MonitorConfig();
+    
+    // Empty archetype settings
+    public EmptyArchetypeConfig emptyArchetype = new EmptyArchetypeConfig();
+    
+    // Logging settings
+    public LoggingConfig logging = new LoggingConfig();
+    
+    // Transformer toggles (for early plugin)
+    public TransformersConfig transformers = new TransformersConfig();
+    
+    // World transformer settings
+    public WorldConfig world = new WorldConfig();
+    
+    // Early plugin logging
+    public EarlyConfig early = new EarlyConfig();
+
+    /**
+     * Chunk unload configuration
+     */
+    public static class ChunkUnloadConfig {
+        public boolean enabled = true;
+        public int intervalSeconds = 30;
+        public int initialDelaySeconds = 10;
+        public int gcEveryNAttempts = 5;
+    }
+
+    /**
+     * Chunk cleanup configuration
+     */
+    public static class ChunkCleanupConfig {
+        public int intervalTicks = 600; // 30 seconds at 20 TPS
+    }
+
+    /**
+     * Sanitizer toggle configuration
+     */
+    public static class SanitizersConfig {
+        public boolean pickupItem = true;
+        public boolean respawnBlock = true;
+        public boolean processingBench = true;
+        public boolean craftingManager = true;
+        public boolean interactionManager = true;
+        public boolean spawnBeacon = true;
+        public boolean chunkTracker = true;
+        public boolean gatherObjective = true;
+        public boolean emptyArchetype = true;
+        public boolean instancePositionTracker = true;
+        public boolean pickupItemChunkHandler = true;
+    }
+
+    /**
+     * Interaction manager configuration
+     */
+    public static class InteractionManagerConfig {
+        public long clientTimeoutMs = 2000;
+    }
+
+    /**
+     * Instance tracker configuration
+     */
+    public static class InstanceTrackerConfig {
+        public int positionTtlHours = 24;
+    }
+
+    /**
+     * Monitor configuration
+     */
+    public static class MonitorConfig {
+        public int logIntervalTicks = 6000; // 5 minutes at 20 TPS
+    }
+
+    /**
+     * Empty archetype configuration
+     */
+    public static class EmptyArchetypeConfig {
+        public int skipFirstN = 1000;
+        public int logEveryN = 10000;
+    }
+
+    /**
+     * Logging configuration
+     */
+    public static class LoggingConfig {
+        public boolean verbose = false;
+        public boolean sanitizerActions = true;
+    }
+
+    /**
+     * Transformer toggle configuration (for early plugin)
+     */
+    public static class TransformersConfig {
+        public boolean interactionChain = true;
+        public boolean world = true;
+        public boolean spawnReferenceSystems = true;
+        public boolean beaconSpawnController = true;
+        public boolean blockComponentChunk = true;
+        public boolean spawnMarkerSystems = true;
+        public boolean spawnMarkerEntity = true;
+        public boolean trackedPlacement = true;
+        public boolean commandBuffer = true;
+        public boolean worldMapTracker = true;
+        public boolean archetypeChunk = true;
+    }
+
+    /**
+     * World transformer configuration
+     */
+    public static class WorldConfig {
+        public int retryCount = 5;
+        public long retryDelayMs = 20;
+    }
+
+    /**
+     * Early plugin configuration
+     */
+    public static class EarlyConfig {
+        public EarlyLoggingConfig logging = new EarlyLoggingConfig();
+    }
+
+    /**
+     * Early plugin logging configuration
+     */
+    public static class EarlyLoggingConfig {
+        public boolean verbose = false;
+    }
+}

--- a/src/main/java/com/hyfixes/listeners/EmptyArchetypeSanitizer.java
+++ b/src/main/java/com/hyfixes/listeners/EmptyArchetypeSanitizer.java
@@ -1,6 +1,7 @@
 package com.hyfixes.listeners;
 
 import com.hyfixes.HyFixes;
+import com.hyfixes.config.ConfigManager;
 import com.hypixel.hytale.component.ArchetypeChunk;
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.ComponentType;
@@ -45,8 +46,15 @@ public class EmptyArchetypeSanitizer extends EntityTickingSystem<EntityStore> {
     private int checkedCount = 0;
     private int removedCount = 0;
 
+    // Configuration (loaded from ConfigManager)
+    private final int skipFirstN;
+    private final int logEveryN;
+
     public EmptyArchetypeSanitizer(HyFixes plugin) {
         this.plugin = plugin;
+        ConfigManager config = ConfigManager.getInstance();
+        this.skipFirstN = config.getEmptyArchetypeSkipFirstN();
+        this.logEveryN = config.getEmptyArchetypeLogEveryN();
     }
 
     @Override
@@ -74,14 +82,14 @@ public class EmptyArchetypeSanitizer extends EntityTickingSystem<EntityStore> {
             // Get the TransformComponent
             TransformComponent transform = chunk.getComponent(entityIndex, TransformComponent.getComponentType());
 
-            // Skip first 1000 entities silently to avoid log spam on startup
+            // Skip first N entities silently to avoid log spam on startup
             checkedCount++;
-            if (checkedCount <= 1000) {
+            if (checkedCount <= skipFirstN) {
                 return;
             }
 
             // Only log occasionally to avoid spam
-            if (checkedCount % 10000 == 0) {
+            if (checkedCount % logEveryN == 0) {
                 plugin.getLogger().at(Level.FINE).log(
                     "[EmptyArchetypeSanitizer] Checked " + checkedCount + " entities"
                 );

--- a/src/main/java/com/hyfixes/systems/ChunkCleanupSystem.java
+++ b/src/main/java/com/hyfixes/systems/ChunkCleanupSystem.java
@@ -1,6 +1,7 @@
 package com.hyfixes.systems;
 
 import com.hyfixes.HyFixes;
+import com.hyfixes.config.ConfigManager;
 import com.hypixel.hytale.component.ArchetypeChunk;
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Store;
@@ -20,7 +21,7 @@ import java.util.logging.Level;
  * This system extends EntityTickingSystem to ensure our cleanup methods
  * are called from the main server thread, avoiding InvocationTargetExceptions.
  *
- * It runs every CLEANUP_INTERVAL_TICKS ticks (default: 600 = 30 seconds at 20 TPS)
+ * It runs every cleanupIntervalTicks ticks (default: 600 = 30 seconds at 20 TPS)
  *
  * NOTE: We only call invalidateLoadedChunks() here. The waitForLoadingChunks()
  * method was removed because calling it from within a system tick causes
@@ -31,8 +32,8 @@ public class ChunkCleanupSystem extends EntityTickingSystem<EntityStore> {
 
     private final HyFixes plugin;
 
-    // Configuration
-    private static final int CLEANUP_INTERVAL_TICKS = 600; // 30 seconds at 20 TPS
+    // Configuration (loaded from ConfigManager)
+    private final int cleanupIntervalTicks;
 
     // State
     private final AtomicInteger tickCounter = new AtomicInteger(0);
@@ -51,6 +52,7 @@ public class ChunkCleanupSystem extends EntityTickingSystem<EntityStore> {
 
     public ChunkCleanupSystem(HyFixes plugin) {
         this.plugin = plugin;
+        this.cleanupIntervalTicks = ConfigManager.getInstance().getChunkCleanupIntervalTicks();
     }
 
     @Override
@@ -76,7 +78,7 @@ public class ChunkCleanupSystem extends EntityTickingSystem<EntityStore> {
         if (!loggedOnce) {
             plugin.getLogger().at(Level.INFO).log(
                 "[ChunkCleanupSystem] Active on MAIN THREAD - will run cleanup every " +
-                (CLEANUP_INTERVAL_TICKS / 20) + " seconds"
+                (cleanupIntervalTicks / 20) + " seconds"
             );
             loggedOnce = true;
         }
@@ -84,8 +86,8 @@ public class ChunkCleanupSystem extends EntityTickingSystem<EntityStore> {
         // Increment tick counter
         int currentTick = tickCounter.incrementAndGet();
 
-        // Only run cleanup every CLEANUP_INTERVAL_TICKS
-        if (currentTick % CLEANUP_INTERVAL_TICKS != 0) {
+        // Only run cleanup every cleanupIntervalTicks
+        if (currentTick % cleanupIntervalTicks != 0) {
             return;
         }
 
@@ -207,7 +209,7 @@ public class ChunkCleanupSystem extends EntityTickingSystem<EntityStore> {
             successCount.get(),
             threadErrorCount.get(),
             lastRunStr,
-            CLEANUP_INTERVAL_TICKS / 20
+            cleanupIntervalTicks / 20
         );
     }
 }

--- a/src/main/java/com/hyfixes/systems/InteractionChainMonitor.java
+++ b/src/main/java/com/hyfixes/systems/InteractionChainMonitor.java
@@ -1,6 +1,7 @@
 package com.hyfixes.systems;
 
 import com.hyfixes.HyFixes;
+import com.hyfixes.config.ConfigManager;
 import com.hypixel.hytale.component.ArchetypeChunk;
 import com.hypixel.hytale.component.CommandBuffer;
 import com.hypixel.hytale.component.Store;
@@ -39,8 +40,8 @@ public class InteractionChainMonitor extends EntityTickingSystem<EntityStore> {
 
     private final HyFixes plugin;
 
-    // Timing
-    private static final int LOG_INTERVAL_TICKS = 6000; // 5 minutes at 20 TPS
+    // Timing (configurable)
+    private final int logIntervalTicks;
     private final AtomicInteger tickCounter = new AtomicInteger(0);
     private final AtomicLong startTime = new AtomicLong(System.currentTimeMillis());
     private final AtomicLong lastLogTime = new AtomicLong(0);
@@ -87,6 +88,7 @@ public class InteractionChainMonitor extends EntityTickingSystem<EntityStore> {
 
     public InteractionChainMonitor(HyFixes plugin) {
         this.plugin = plugin;
+        this.logIntervalTicks = ConfigManager.getInstance().getMonitorLogIntervalTicks();
     }
 
     @Override
@@ -117,7 +119,7 @@ public class InteractionChainMonitor extends EntityTickingSystem<EntityStore> {
         int ticks = tickCounter.incrementAndGet();
 
         // Periodic logging
-        if (ticks % LOG_INTERVAL_TICKS == 0) {
+        if (ticks % logIntervalTicks == 0) {
             logPeriodicSummary();
         }
     }

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "Group": "com.hyfixes",
   "Name": "HyFixes",
-  "Version": "1.6.2",
+  "Version": "1.7.0",
   "Description": "Essential bug fixes for Hytale Early Access servers. Prevents crashes, player kicks, and sync issues.",
   "Main": "com.hyfixes.HyFixes",
   "Authors": [


### PR DESCRIPTION
## Summary

Replace hardcoded values and environment variables with a proper JSON configuration file at `mods/hyfixes/config.json`. Server admins can now customize every aspect of HyFixes without modifying code or setting up complex environment variables.

- ✅ Full control over individual sanitizers (11 toggles)
- ✅ Full control over individual bytecode transformers (11 toggles)  
- ✅ Configurable timing values (intervals, delays, thresholds)
- ✅ Auto-generation of default config on first run
- ✅ Backwards compatibility with existing ENV variables

## Configuration Reference

### Config File Location

```
mods/
  hyfixes/
    config.json     # Auto-generated on first run
  hyfixes.jar
  hyfixes-early.jar
```

### Complete Configuration Options

<details>
<summary><b>🔧 Chunk Unload Settings</b></summary>

| Setting | Default | Description |
|---------|---------|-------------|
| `chunkUnload.enabled` | `true` | Enable/disable aggressive chunk unloading. **Disable if using BetterMap!** |
| `chunkUnload.intervalSeconds` | `30` | How often to run chunk cleanup |
| `chunkUnload.initialDelaySeconds` | `10` | Delay before first cleanup after server start |
| `chunkUnload.gcEveryNAttempts` | `5` | Force garbage collection every N cleanup attempts |

</details>

<details>
<summary><b>🛡️ Sanitizer Toggles</b></summary>

Toggle individual bug-fix sanitizers on/off:

| Setting | Default | Description |
|---------|---------|-------------|
| `sanitizers.pickupItem` | `true` | Fix item pickup null pointer exceptions |
| `sanitizers.respawnBlock` | `true` | Fix respawn block sync issues |
| `sanitizers.processingBench` | `true` | Fix processing bench crashes |
| `sanitizers.craftingManager` | `true` | Fix crafting manager null checks |
| `sanitizers.interactionManager` | `true` | Fix stuck interaction chains |
| `sanitizers.spawnBeacon` | `true` | Fix spawn beacon null references |
| `sanitizers.chunkTracker` | `true` | Fix chunk tracker sync issues |
| `sanitizers.gatherObjective` | `true` | Fix gather objective task crashes |
| `sanitizers.emptyArchetype` | `true` | Fix empty archetype entity issues |
| `sanitizers.instancePositionTracker` | `true` | Track player positions across instances |
| `sanitizers.pickupItemChunkHandler` | `true` | Fix pickup items in unloaded chunks |

</details>

<details>
<summary><b>⚡ Bytecode Transformer Toggles (Early Plugin)</b></summary>

Toggle individual bytecode transformers on/off:

| Setting | Default | Issue Fixed |
|---------|---------|-------------|
| `transformers.interactionChain` | `true` | Sync buffer overflow in putInteractionSyncData() |
| `transformers.world` | `true` | addPlayer() race condition (#7) |
| `transformers.spawnReferenceSystems` | `true` | Null spawnController crash |
| `transformers.beaconSpawnController` | `true` | Null spawn in createRandomSpawnJob() |
| `transformers.blockComponentChunk` | `true` | Duplicate block components (#8) |
| `transformers.spawnMarkerSystems` | `true` | Null npcReferences in onEntityRemove() |
| `transformers.spawnMarkerEntity` | `true` | Initialize npcReferences array |
| `transformers.trackedPlacement` | `true` | BlockCounter decrement (#11) |
| `transformers.commandBuffer` | `true` | removeComponent race condition (#12) |
| `transformers.worldMapTracker` | `true` | Iterator corruption in unloadImages() (#16) |
| `transformers.archetypeChunk` | `true` | Stale entity getComponent() crash (#20) |

</details>

<details>
<summary><b>⏱️ Timing Settings</b></summary>

| Setting | Default | Description |
|---------|---------|-------------|
| `chunkCleanup.intervalTicks` | `600` | Main-thread cleanup interval (600 = 30s at 20 TPS) |
| `interactionManager.clientTimeoutMs` | `2000` | Timeout before removing stuck interaction chains |
| `monitor.logIntervalTicks` | `6000` | Stats logging interval (6000 = 5 min at 20 TPS) |
| `instanceTracker.positionTtlHours` | `24` | How long to keep saved player positions |

</details>

<details>
<summary><b>🔄 World Race Condition Settings</b></summary>

| Setting | Default | Description |
|---------|---------|-------------|
| `world.retryCount` | `5` | Number of retries for World.addPlayer() race condition |
| `world.retryDelayMs` | `20` | Delay between retries in milliseconds |

</details>

<details>
<summary><b>📝 Logging Settings</b></summary>

| Setting | Default | Description |
|---------|---------|-------------|
| `logging.verbose` | `false` | Enable verbose debug logging |
| `logging.sanitizerActions` | `true` | Log when sanitizers take action |
| `early.logging.verbose` | `false` | Enable verbose transformation logging |

</details>

### Example config.json

```json
{
  "chunkUnload": {
    "enabled": true,
    "intervalSeconds": 30,
    "initialDelaySeconds": 10,
    "gcEveryNAttempts": 5
  },
  "chunkCleanup": {
    "intervalTicks": 600
  },
  "sanitizers": {
    "pickupItem": true,
    "respawnBlock": true,
    "processingBench": true,
    "craftingManager": true,
    "interactionManager": true,
    "spawnBeacon": true,
    "chunkTracker": true,
    "gatherObjective": true,
    "emptyArchetype": true,
    "instancePositionTracker": true,
    "pickupItemChunkHandler": true
  },
  "transformers": {
    "interactionChain": true,
    "world": true,
    "spawnReferenceSystems": true,
    "beaconSpawnController": true,
    "blockComponentChunk": true,
    "spawnMarkerSystems": true,
    "spawnMarkerEntity": true,
    "trackedPlacement": true,
    "commandBuffer": true,
    "worldMapTracker": true,
    "archetypeChunk": true
  },
  "interactionManager": {
    "clientTimeoutMs": 2000
  },
  "instanceTracker": {
    "positionTtlHours": 24
  },
  "monitor": {
    "logIntervalTicks": 6000
  },
  "emptyArchetype": {
    "skipFirstN": 1000,
    "logEveryN": 10000
  },
  "world": {
    "retryCount": 5,
    "retryDelayMs": 20
  },
  "logging": {
    "verbose": false,
    "sanitizerActions": true
  },
  "early": {
    "logging": {
      "verbose": false
    }
  }
}
```

### Backwards Compatibility

Existing environment variables still work and take precedence over config file:
- `HYFIXES_DISABLE_CHUNK_UNLOAD=true` → Disables chunk unloading
- `HYFIXES_VERBOSE=true` → Enables verbose logging

## Files Changed

**New Files (4):**
- `src/main/java/com/hyfixes/config/ConfigManager.java` - Config loading/saving singleton
- `src/main/java/com/hyfixes/config/HyFixesConfig.java` - Config data class
- `hyfixes-early/src/main/java/com/hyfixes/early/config/EarlyConfigManager.java` - Early plugin config loader
- `hyfixes-early/src/main/java/com/hyfixes/early/config/EarlyPluginConfig.java` - Early plugin config data class

**Modified Files (21):**
- All 11 transformers - Added config check before transforming
- All runtime systems/sanitizers - Now read values from config
- `HyFixes.java` - Config initialization and conditional sanitizer registration

## Test Plan

- [x] Delete config file → Verify default is auto-generated
- [x] Server starts with all 14 bug fixes active
- [x] Config values logged on startup
- [ ] Modify config values → Verify they take effect on restart
- [ ] Disable a sanitizer → Verify it doesn't register
- [ ] Set ENV variable → Verify it overrides config

## Deployment

Already tested on dev server - config file generated successfully at `mods/hyfixes/config.json` and all fixes active.

---

🤖 Generated with [Claude Code](https://claude.ai/code)